### PR TITLE
Colony UI and logic update

### DIFF
--- a/packages/pando-colony/app/src/App.js
+++ b/packages/pando-colony/app/src/App.js
@@ -1,15 +1,10 @@
+import { Main } from '@aragon/ui'
 import React from 'react'
-import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import { EmptyStateCard, Main, SidePanel, observe, theme } from '@aragon/ui'
 import AppLayout from './components/AppLayout'
 import NewRepositoryIcon from './components/NewRepositoryIcon'
 import NewRepositorySidePanel from './components/NewRepositorySidePanel'
 import EmptyState from './screens/EmptyState'
 import Repositories from './screens/Repositories'
-import repositories from './data'
-
-
 export default class App extends React.Component {
   constructor(props) {
     super(props)
@@ -31,15 +26,13 @@ export default class App extends React.Component {
     this.setState({ sidePanelOpen: false })
   }
 
-  handleCreateRepository= (name, description) => {
+  handleCreateRepository = (name, description) => {
     this.props.app.createRepository(name, description)
   }
 
   render() {
-    // const { repositories } = this.props
+    const { repos } = this.props
     const { sidePanelOpen } = this.state
-
-      console.log(repositories)
 
     return (
       <div css="min-width: 320px">
@@ -53,8 +46,8 @@ export default class App extends React.Component {
               onClick: this.handleSidePanelOpen,
             }}
           >
-            {repositories.length > 0 ? (
-              <Repositories repositories={repositories} />
+            {repos.length > 0 ? (
+              <Repositories repositories={repos} />
             ) : (
               <EmptyState onActivate={this.handleSidePanelOpen} />
             )}

--- a/packages/pando-colony/app/src/index.js
+++ b/packages/pando-colony/app/src/index.js
@@ -1,14 +1,14 @@
+import Aragon, { providers } from '@aragon/client'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import Aragon, { providers } from '@aragon/client'
 import App from './App'
 
 class ConnectedApp extends React.Component {
   state = {
     app: new Aragon(new providers.WindowMessage(window.parent)),
     network: {},
-    observable: null,
     userAccount: '',
+    repos: [],
   }
   componentDidMount() {
     window.addEventListener('message', this.handleWrapperMessage)
@@ -23,12 +23,14 @@ class ConnectedApp extends React.Component {
     if (data.name === 'ready') {
       const { app } = this.state
       this.sendMessageToWrapper('ready', true)
-      this.setState({ observable: app.state() })
       app.accounts().subscribe(accounts => {
         this.setState({ userAccount: accounts[0] || '' })
       })
       app.network().subscribe(network => {
         this.setState({ network })
+      })
+      app.state().subscribe(state => {
+        this.setState({ repos: state.repos })
       })
     }
   }

--- a/packages/pando-colony/app/src/screens/Repositories.js
+++ b/packages/pando-colony/app/src/screens/Repositories.js
@@ -1,44 +1,59 @@
+import {
+  AddressField,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  Text,
+  Viewport,
+} from '@aragon/ui'
 import React from 'react'
-import styled from 'styled-components'
-import { Badge, Text, theme } from '@aragon/ui'
+import Box from '../components/Box'
 
 export default class Repositories extends React.Component {
   render() {
     const { repositories } = this.props
 
-    console.log(repositories)
-
     return (
-      <Wrapper>
-        <React.Fragment>
-          {
-            repositories.map((repository) => (
-
-              <Repository key={repository.address}>
-                <div className="name"><Text size="x-large" weight="bold">{repository.name}</Text></div>
-                <div className="address"><Badge.Identity>{repository.address}</Badge.Identity></div>
-                <div className="description"><Text>{repository.description}</Text></div>
-              </Repository>
-            ))
-
-          }
-        </React.Fragment>
-      </Wrapper>
+      <Viewport>
+        {({ above, below }) => (
+          <Table
+            header={
+              <TableRow>
+                <TableHeader title="Repository" />
+                {above('medium') && <TableHeader title="Address" />}
+              </TableRow>
+            }
+          >
+            {repositories.map(repository => (
+              <TableRow key={repository.address}>
+                <TableCell>
+                  <div>
+                    <div>
+                      <Text size="xlarge" weight="bold">
+                        {repository.name}
+                      </Text>
+                    </div>
+                    <div>
+                      <Text>{repository.description}</Text>
+                    </div>
+                    {below('medium') && (
+                      <Box mt="1rem">
+                        <AddressField address={repository.address} />
+                      </Box>
+                    )}
+                  </div>
+                </TableCell>
+                {above('medium') && (
+                  <TableCell>
+                    <AddressField address={repository.address} />
+                  </TableCell>
+                )}
+              </TableRow>
+            ))}
+          </Table>
+        )}
+      </Viewport>
     )
   }
 }
-
-const Wrapper = styled.div`
-  margin: auto;
-`
-
-const Repository = styled.div`
-  border-bottom: 1px solid ${theme.contentBorder};
-  padding: 30px;
-  &:first-child {
-    border-top: 1px solid ${theme.contentBorder};
-  }
-  .name {
-    color: ${theme.accent};
-  }
-`

--- a/packages/pando-colony/app/src/script.js
+++ b/packages/pando-colony/app/src/script.js
@@ -1,12 +1,36 @@
 import Aragon from '@aragon/client'
+import PandoRepository from '../../build/contracts/PandoRepository.json'
 
 const app = new Aragon()
 
 app.store(async (state, event) => {
-  switch (event.event) {
-    case 'DeployOrganism':
-      return state
-    default:
-      return state
+  if (!state) {
+    state = { repos: [], cache: {} }
   }
+
+  if (!state.cache[event.id]) {
+    state.cache[event.id] = true
+
+    switch (event.event) {
+      case 'CreateRepository':
+        const address = event.returnValues.repository
+        let result = await getRepo(address)
+        result.address = address
+        state.repos.push(result)
+        return state
+      default:
+        return state
+    }
+  }
+
+  return state
 })
+
+function getRepo(address) {
+  return new Promise(async (resolve, reject) => {
+    const repo = app.external(address, PandoRepository.abi)
+    const name = await repo.name().toPromise()
+    const description = await repo.description().toPromise()
+    resolve({ name, description })
+  })
+}

--- a/packages/pando-repository/contracts/PandoRepository.sol
+++ b/packages/pando-repository/contracts/PandoRepository.sol
@@ -28,9 +28,9 @@ contract PandoRepository is AragonApp {
       uint256 value;
     }
 
-    string name;
-    string description;
-    mapping (string => string) refs;
+    string public name;
+    string public description;
+    mapping (string => string) public refs;
 
     event UpdateRef(string ref, string hash);
     event UpdateInformations(string name, string description);


### PR DESCRIPTION
## Preview
![Colony UI](https://i.gyazo.com/2714ee86ae3f16cc90af316befbc42fb.png "Colony UI update")

Fixes #26 

We need to update `@pando/repository/contracts/PandoRepository.sol` in order for this to work.

One thing that has not been addressed yet is the click action when you click on a specific repo on the list. What should happen and how should we handle that? Since we don't have control over the wrapper - we can't redirect to a different URL.

Cheers!